### PR TITLE
fix(ci): remove the github token variable from workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,13 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 22
+          node-version: 18
       - run: npm install
 
       - name: Publish
         run: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: 'Dependant Bot'
           GIT_AUTHOR_EMAIL: 'release-bot@codedependant.net'
           GIT_COMMITTER_NAME: 'Dependant Bot'


### PR DESCRIPTION
We shouldn't need to setup a custom token for github in github. the temporary token that is issued in each run should have enough rights to push back to the repo at the least