### PR TITLE
chore(ci): use the built-in github token for actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Publish
         run: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.DEPENDANTBOT_TOKEN }}
-          GH_TOKEN: ${{ secrets.DEPENDANTBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: 'Dependant Bot'
           GIT_AUTHOR_EMAIL: 'release-bot@codedependant.net'
           GIT_COMMITTER_NAME: 'Dependant Bot'


### PR DESCRIPTION
The actions runners should have an access token that is sufficient for semantic release to do its things. The repo had to have read + write access granted, rather than read only permissions